### PR TITLE
chore: add .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+website/bin

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "styled-components"
   ],
   "scripts": {
-    "lint": "eslint . --ignore-path .gitignore",
+    "lint": "eslint .",
     "prettier": "prettier --write \"{lib,website,scripts}/*.js\"",
     "test": "jest",
     "build": "node scripts/build",


### PR DESCRIPTION
With the following, editors don't know how to exclude files:

    eslint . --ignore-path .gitignore

https://github.com/eslint/eslint/issues/3529