### PR TITLE
Make possible to pass numbers inside "rows"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Props:
 * `gap`: Gap between cells. Default is `"8px"`.
 * `minRowHeight`: Minimum height of each row. Default is `"20px"`.
 * `flow`: The [grid-auto-flow] CSS property. Default is `"row"`.
-* `rows`: The [grid-template-rows] CSS property. Not provided by default.
+* `rows`: The [grid-template-rows] CSS property. When a number is passed
+  it is a shorthand to specify the number of columns. Not provided by default.
 * `areas`: The [grid-template-areas] CSS property. Pass an array of strings, e.g. `["a a", "b c"]`. Not provided by default.
 * `justifyContent`: The [justify-content] CSS property. Not provided by default.
 * `alignContent`: The [align-content] CSS property. Not provided by default.

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 
 const autoRows = ({ minRowHeight = "20px" }) => `minmax(${minRowHeight}, auto)`;
 
-const columns = ({ columns = 12 }) =>
-  typeof columns === "number" ? `repeat(${columns}, 1fr)` : columns;
+const frGetter = (value = 12) =>
+  typeof value === "number" ? `repeat(${value}, 1fr)` : value;
 
 const gap = ({ gap = "8px" }) => `${gap} ${gap}`;
 
@@ -16,8 +16,8 @@ const Grid = styled.div`
   display: grid;
   grid-auto-flow: ${flow};
   grid-auto-rows: ${autoRows};
-  ${({ rows }) => rows && `grid-template-rows: ${rows}`};
-  grid-template-columns: ${columns};
+  ${({ rows }) => `grid-template-rows: ${frGetter(rows)}`};
+  grid-template-columns: ${({ columns }) => frGetter(columns)};
   grid-gap: ${gap};
   ${({ areas }) => areas && `grid-template-areas: ${formatAreas(areas)}`};
   ${({ justifyContent }) =>
@@ -31,7 +31,7 @@ Grid.propTypes = {
   gap: PropTypes.string,
   minRowHeight: PropTypes.string,
   flow: PropTypes.string,
-  rows: PropTypes.string,
+  rows: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   areas: PropTypes.arrayOf(PropTypes.string),
   justifyContent: PropTypes.string,
   alignContent: PropTypes.string

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 const autoRows = ({ minRowHeight = "20px" }) => `minmax(${minRowHeight}, auto)`;
 
-const frGetter = (value = 12) =>
+const frGetter = value =>
   typeof value === "number" ? `repeat(${value}, 1fr)` : value;
 
 const gap = ({ gap = "8px" }) => `${gap} ${gap}`;
@@ -16,8 +16,13 @@ const Grid = styled.div`
   display: grid;
   grid-auto-flow: ${flow};
   grid-auto-rows: ${autoRows};
-  ${({ rows }) => `grid-template-rows: ${frGetter(rows)}`};
-  grid-template-columns: ${({ columns }) => frGetter(columns)};
+  ${({ rows }) => {
+    console.log(rows);
+    if (rows) {
+      return `grid-template-rows: ${frGetter(rows)}`;
+    }
+  }}
+  grid-template-columns: ${({ columns = 12 }) => frGetter(columns)};
   grid-gap: ${gap};
   ${({ areas }) => areas && `grid-template-areas: ${formatAreas(areas)}`};
   ${({ justifyContent }) =>

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -16,12 +16,7 @@ const Grid = styled.div`
   display: grid;
   grid-auto-flow: ${flow};
   grid-auto-rows: ${autoRows};
-  ${({ rows }) => {
-    console.log(rows);
-    if (rows) {
-      return `grid-template-rows: ${frGetter(rows)}`;
-    }
-  }}
+  ${({ rows }) => rows && `grid-template-rows: ${frGetter(rows)}`};
   grid-template-columns: ${({ columns = 12 }) => frGetter(columns)};
   grid-gap: ${gap};
   ${({ areas }) => areas && `grid-template-areas: ${formatAreas(areas)}`};

--- a/lib/__tests__/Grid.test.js
+++ b/lib/__tests__/Grid.test.js
@@ -25,6 +25,11 @@ describe("<Grid />", () => {
     );
   });
 
+  test("'rows' as number prop sets 'grid-template-rows' to repeat()", () => {
+    const tree = renderer.create(<Grid rows={7} />).toJSON();
+    expect(tree).toHaveStyleRule("grid-template-rows", "repeat(7,1fr)");
+  });
+
   test("'rows' as string prop sets 'grid-template-rows'", () => {
     const tree = renderer.create(<Grid rows="1fr 2fr 1fr" />).toJSON();
     expect(tree).toHaveStyleRule("grid-template-rows", "1fr 2fr 1fr");

--- a/lib/__tests__/__snapshots__/Grid.test.js.snap
+++ b/lib/__tests__/__snapshots__/Grid.test.js.snap
@@ -5,7 +5,6 @@ exports[`<Grid /> matches snapshot with default args 1`] = `
   display: grid;
   grid-auto-flow: row;
   grid-auto-rows: minmax(20px,auto);
-  grid-template-rows: repeat(12,1fr);
   grid-template-columns: repeat(12,1fr);
   grid-gap: 8px 8px;
 }

--- a/lib/__tests__/__snapshots__/Grid.test.js.snap
+++ b/lib/__tests__/__snapshots__/Grid.test.js.snap
@@ -5,6 +5,7 @@ exports[`<Grid /> matches snapshot with default args 1`] = `
   display: grid;
   grid-auto-flow: row;
   grid-auto-rows: minmax(20px,auto);
+  grid-template-rows: repeat(12,1fr);
   grid-template-columns: repeat(12,1fr);
   grid-gap: 8px 8px;
 }


### PR DESCRIPTION
As "columns" and "rows" do pretty much the same, the two properties should work in a similar way.
The difference is that "columns" has a default value of `12`, where "rows" has nothing.