### PR TITLE
Add tag props to grid and cell components

### DIFF
--- a/lib/Cell.js
+++ b/lib/Cell.js
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
+import tag from "clean-tag";
 
-const Cell = styled.section`
+const Cell = styled(tag.section)`
   height: 100%;
   min-width: 0;
   align-content: space-around;
@@ -32,7 +33,8 @@ Cell.propTypes = {
   left: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   middle: PropTypes.bool,
   center: PropTypes.bool,
-  area: PropTypes.string
+  area: PropTypes.string,
+  is: PropTypes.string
 };
 
 export default Cell;

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
+import tag from "clean-tag";
 
 const autoRows = ({ minRowHeight = "20px" }) => `minmax(${minRowHeight}, auto)`;
 
@@ -12,7 +13,7 @@ const flow = ({ flow = "row" }) => flow;
 
 const formatAreas = areas => areas.map(area => `"${area}"`).join(" ");
 
-const Grid = styled.div`
+const Grid = styled(tag.section)`
   display: grid;
   height: ${({ height = "auto" }) => height};
   grid-auto-flow: ${flow};
@@ -36,7 +37,8 @@ Grid.propTypes = {
   rows: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   areas: PropTypes.arrayOf(PropTypes.string),
   justifyContent: PropTypes.string,
-  alignContent: PropTypes.string
+  alignContent: PropTypes.string,
+  is: PropTypes.string
 };
 
 export default Grid;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "peerDependencies": {
+    "clean-tag": "^1.0.4",
     "react": "*",
     "react-dom": "*",
     "styled-components": "^2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,6 +940,14 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
+clean-tag@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clean-tag/-/clean-tag-1.0.4.tgz#9b407b306fadce114e6dffa774e7b61bdfc0c190"
+  dependencies:
+    html-tags "^2.0.0"
+    react ">=16.0.0"
+    styled-system ">=1.1 || >=2.0"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -1885,6 +1893,10 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+html-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
 http-proxy@^1.8.1:
   version "1.16.2"
@@ -3309,6 +3321,15 @@ react-test-renderer@next:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
+react@>=16.0.0:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react@next:
   version "16.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0-beta.2.tgz#340bbaa28c8678499353586cf46d096438dee561"
@@ -3974,6 +3995,12 @@ styled-components@^2.1.1:
     prop-types "^15.5.4"
     stylis "^3.2.1"
     supports-color "^3.2.3"
+
+"styled-system@>=1.1 || >=2.0":
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-2.2.9.tgz#1a9a2187b1856b4a385ed65a1daff771a253f3d9"
+  dependencies:
+    prop-types "^15.6.0"
 
 stylis@^3.2.1:
   version "3.2.8"


### PR DESCRIPTION
As proposed in this issue https://github.com/azz/styled-css-grid/issues/41 ...

Which allows to do something like : 

```
<Grid is="ul">
  <Cell is="li" width={3}>
    item 1
   </Cell>
   <Cell is="li" width={3}>
      item 2
    </Cell>
  </Grid>
```