### PR TITLE
Fix middle style across browsers

### DIFF
--- a/lib/Cell.js
+++ b/lib/Cell.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 const Cell = styled.section`
   height: 100%;
   min-width: 0;
-  align-content: space-around;
   grid-column-end: ${({ width = 1 }) => `span ${width}`};
   grid-row-end: ${({ height = 1 }) => `span ${height}`};
 

--- a/lib/__tests__/__snapshots__/Cell.test.js.snap
+++ b/lib/__tests__/__snapshots__/Cell.test.js.snap
@@ -4,9 +4,6 @@ exports[`<Cell/> 'middle' prop vertically aligns contents 1`] = `
 .c0 {
   height: 100%;
   min-width: 0;
-  -webkit-align-content: space-around;
-  -ms-flex-line-pack: space-around;
-  align-content: space-around;
   grid-column-end: span 1;
   grid-row-end: span 1;
   display: -webkit-inline-box;
@@ -35,9 +32,6 @@ exports[`<Cell/> matches snapshot with default args 1`] = `
 .c0 {
   height: 100%;
   min-width: 0;
-  -webkit-align-content: space-around;
-  -ms-flex-line-pack: space-around;
-  align-content: space-around;
   grid-column-end: span 1;
   grid-row-end: span 1;
 }


### PR DESCRIPTION
I noticed that there was a bug in Firefox when using the `middle` prop and opened https://github.com/azz/styled-css-grid/issues/45. I then also noticed the same issue appears is Edge.

Removing the `align-content: space-around` styled completely fixes the issue and does not appear to cause any issues with any other demos. 

Here are some screenshots from various browsers of the offending demo:

## Safari
![safari](https://user-images.githubusercontent.com/425261/44034335-c35b0fa8-9f04-11e8-95b0-54b4fac96283.png)

## Chrome
![chrome](https://user-images.githubusercontent.com/425261/44034292-a5f640f4-9f04-11e8-8367-1085cfc1e62c.png)

## Firefox
![firefox](https://user-images.githubusercontent.com/425261/44034293-a60fbb74-9f04-11e8-9d30-58b6f1a44d7c.png)

## Edge
![edge](https://user-images.githubusercontent.com/425261/44034294-a62723d6-9f04-11e8-8a26-e5a026884d52.png)
