### PR TITLE
chore: update styled-components version to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "styled-components": "^2 || ^3"
+    "styled-components": "^2 || ^3 || ^4"
   },
   "dependencies": {
     "prop-types": "^15.6.0"


### PR DESCRIPTION
Hi,

I update version of styled-components to peerDependencies. Already release v4. ref: https://github.com/styled-components/styled-components/releases/tag/v4.0.0
I tried with v4, So actually has not problem.
Thanks.