### PR TITLE
Fix TypeScript definitions not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/azz/styled-css-grid",
   "author": "Lucas Azzola",
   "license": "MIT",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,6 +14,9 @@ sh.mkdir("-p", "./website/bin");
 sh.echo("bundling dist...");
 sh.exec("rollup -c ./scripts/rollup.config.js");
 
+sh.echo("copying typescript definitions to dist...");
+sh.cp("./index.d.ts", "./dist");
+
 sh.echo("bundling website...");
 sh.exec("rollup -c ./scripts/rollup.website.config.js");
 


### PR DESCRIPTION
This fixes an issue where TypeScript definitions didn't work because the `index.d.ts` wasn't in the `dist` folder.

When using npm/yarn to install the package, only files within `dist` would be installed, but `index.d.ts` would be left out, as it wasn't copied over during the build process.