### PR TITLE
feat: allow styled-components versions 5 and 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "styled-components": "^2 || ^3 || ^4"
+    "styled-components": "^2 || ^3 || ^4 || ^5 || ^6"
   },
   "dependencies": {
     "prop-types": "^15.6.0"


### PR DESCRIPTION
Hi @azz! Thanks for providing this brilliant little package, it has served us well over the years. As evidenced by the still increasing number of weekly downloads (see https://npmtrends.com/styled-css-grid), it is still quite popular.

We recently updated `styled-components` to v6, and have been getting the following warning:

```
styled-components is listed by your project with version 6.1.11, which doesn't satisfy what styled-css-grid (pcb12c) requests (^2.0.0 || ^3.0.0 || ^4.0.0)
```

However, we have found that there are no actual compatibility problems. Everything still works. It would be great if you could consider merging this pull request and releasing a new version.